### PR TITLE
I needed a little flexibility in how I present subtitles... so I added some.

### DIFF
--- a/kia-subtitle.php
+++ b/kia-subtitle.php
@@ -11,7 +11,7 @@ License: GPL2
     Copyright 2012  Kathy Darling  (email: kathy.darling@gmail.com)
 
     This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License, version 2, as 
+    it under the terms of the GNU General Public License, version 2, as
     published by the Free Software Foundation.
 
     This program is distributed in the hope that it will be useful,
@@ -75,18 +75,28 @@ class KIA_Subtitle {
      * @output string
      * @since 1.0
      */
-    function the_subtitle(){
-        echo self::get_the_subtitle();
+    function the_subtitle($before = '', $after = '', $echo = true){
+      $subtitle = self::get_the_subtitle();
+
+      if ( strlen($subtitle) == 0 )
+        return;
+
+      $subtitle = $before . $subtitle . $after;
+
+      if ( $echo )
+        echo $subtitle;
+      else
+        return $subtitle;
     }
     /**
      * Returns the Subtitle
-     * @param integer $post_id the post ID for which you'd like to retrieve the 
+     * @param integer $post_id the post ID for which you'd like to retrieve the
      * @return string
      * @since 1.0
      */
     function get_the_subtitle($post_id = null){
-        $post_id = !is_null($post_id) ? $post_id : get_the_ID(); 
-        $sub = get_post_meta($post_id, 'kia_subtitle', true); 
+        $post_id = !is_null($post_id) ? $post_id : get_the_ID();
+        $sub = get_post_meta($post_id, 'kia_subtitle', true);
         return $sub;
     }
     /**
@@ -105,13 +115,13 @@ class KIA_Subtitle {
      * @since 1.0
      */
     function load_scripts( $hook ) {
-     
+
         if( $hook == 'post.php' || $hook == 'post-new.php' || $hook == 'edit.php' ) {
-                
+
             //add the styles and scripts:
             if( $hook == 'post.php' || $hook == 'post-new.php' ) add_action('admin_head',array(__CLASS__,'inline_style'));
             wp_enqueue_script('kia_subtitle', plugins_url('/scripts/subtitle.js', __FILE__), array('jquery'), '1.2', true);
-            
+
             $translation_array = array( 'subtitle' => __( 'Subtitle', 'kia_subtitle' ) );
             wp_localize_script( 'kia_subtitle', 'KIA_Subtitle', $translation_array );
         }
@@ -145,20 +155,20 @@ class KIA_Subtitle {
      * @since 1.0
      */
     function add_input(){
-        
+
         //create the meta field (don't use a metabox, we have our own styling):
         wp_nonce_field( plugin_basename( __FILE__ ), 'kia_subnonce' );
-        
+
         //get the subtitle value (if set)
         if ( $sub = get_post_meta( get_the_ID(), 'kia_subtitle', true ) ) {
-            $prompt = ''; 
+            $prompt = '';
         } else {
             $sub = __( 'Subtitle','kia_subtitle' );
             $prompt = 'prompt';
         }
 
         // echo the inputfield with the value.
-        echo '<input type="text" class="widefat '.$prompt.'" name="subtitle" value="'.$sub.'" id="the_subtitle" tabindex="1"/>';      
+        echo '<input type="text" class="widefat '.$prompt.'" name="subtitle" value="'.$sub.'" id="the_subtitle" tabindex="1"/>';
     }
 
     /**
@@ -167,25 +177,25 @@ class KIA_Subtitle {
      * @since 1.0
      */
     function meta_save( $post_id ){
-        
+
         //check to see if this is an autosafe and if the nonce is verified:
-        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) 
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
             return;
 
         if ( ! isset( $_POST['kia_subnonce'] ) || ! wp_verify_nonce( $_POST['kia_subnonce'], plugin_basename( __FILE__ ) ) )
             return;
-     
+
         // Check permissions
         if ( 'page' == $_POST['post_type'] ) {
             if ( !current_user_can( 'edit_page', $post_id ) ) return;
         } else {
             if ( !current_user_can( 'edit_post', $post_id ) ) return;
         }
-        
+
         //don't save if the subtitle equals the default text (ideally we'd use the placeholder html5 attribute)
         if( in_array ( trim($_POST['subtitle'] ), array( __( 'Subtitle', 'kia_subtitle' ), '' ) ) ) {
             delete_post_meta( $post_id, 'kia_subtitle' );
-        } else { 
+        } else {
             update_post_meta( $post_id, 'kia_subtitle', sanitize_text_field( $_POST['subtitle'] ) );
         }
         return;
@@ -198,13 +208,13 @@ class KIA_Subtitle {
      * @since 1.1
      */
 
-    function column_header( $columns ){ 
+    function column_header( $columns ){
         $new_columns = array();
          foreach( $columns as $key => $value ) {
             $new_columns[ $key ] = $value;
             if ( $key == 'title' )
                $new_columns['subtitle'] = __( 'Subtitle', 'kia_subtitle' );
-         } 
+         }
 
          return $new_columns;
     }
@@ -215,7 +225,7 @@ class KIA_Subtitle {
      * @since 1.1
      */
 
-    function column_value( $column_name, $post_id ){ 
+    function column_value( $column_name, $post_id ){
         switch ( $column_name ) :
             case 'subtitle' :
                 echo $sub = get_post_meta(get_the_ID(), 'kia_subtitle', true);
@@ -230,7 +240,7 @@ class KIA_Subtitle {
      * @since 1.1
      */
 
-    function quick_edit_custom_box( $column_name, $screen ) {   
+    function quick_edit_custom_box( $column_name, $screen ) {
         if($column_name != 'subtitle') return false;
     ?>
             <label class="kia-subtitle">
@@ -240,7 +250,7 @@ class KIA_Subtitle {
                 <?php wp_nonce_field( plugin_basename( __FILE__ ), 'kia_subnonce'); ?>
 
             </label>
-    <?php 
+    <?php
     }
 
 } // end class
@@ -262,8 +272,8 @@ $KIA_Subtitle = new KIA_Subtitle();
 * @since 1.0
 */
 if( ! function_exists( 'the_subtitle' ) ){
-    function the_subtitle(){
-        return KIA_Subtitle::the_subtitle();
+    function the_subtitle($before = '', $after = '', $echo = true){
+        return KIA_Subtitle::the_subtitle($before, $after, $echo);
     }
 }
 


### PR DESCRIPTION
Please disregard the previous pull request; I'd delete it if I could. I really shouldn't have my work email linked to GPL-licensed commits.

Anyway, like I said before, I had a use-case where I needed to wrap the subtitle based on some conditional logic and I thought that using the same logic that I was already using for `the_title()` might be handy... so I patched the logic from `the_title()` into `the_subtitle()`.

I also inadvertently cleaned up whitespace at the end of a LOT of lines. Bonus?
