### PR TITLE
Add HTML Escaping

### DIFF
--- a/kia-subtitle.php
+++ b/kia-subtitle.php
@@ -168,7 +168,7 @@ class KIA_Subtitle {
         }
 
         // echo the inputfield with the value.
-        echo '<input type="text" class="widefat '.$prompt.'" name="subtitle" value="'.$sub.'" id="the_subtitle" tabindex="1"/>';
+        echo '<input type="text" class="widefat '.$prompt.'" name="subtitle" value="'.esc_attr($sub).'" id="the_subtitle" tabindex="1"/>';
     }
 
     /**
@@ -229,7 +229,7 @@ class KIA_Subtitle {
         switch ( $column_name ) :
             case 'subtitle' :
                 echo $sub = get_post_meta( get_the_ID(), 'kia_subtitle', true );
-                echo '<div class="hidden kia-subtitle-value">' . $sub . '</div>';
+                echo '<div class="hidden kia-subtitle-value">' . esc_html($sub) . '</div>';
             break;
         endswitch;
     }
@@ -245,7 +245,7 @@ class KIA_Subtitle {
     ?>
             <label class="kia-subtitle">
                 <span class="title"><?php _e( 'Subtitle', 'kia_subtitle' ) ?></span>
-                <span class="input-text-wrap"><input type="text" name="<?php echo $column_name; ?>" class="ptitle kia-subtitle-input" value=""></span>
+                <span class="input-text-wrap"><input type="text" name="<?php echo esc_attr($column_name); ?>" class="ptitle kia-subtitle-input" value=""></span>
 
                 <?php wp_nonce_field( plugin_basename( __FILE__ ), 'kia_subnonce' ); ?>
 


### PR DESCRIPTION
In theory HTML should be stripped by the use of sanitize_text_field. In practice, some escaping still needs to be done (ie: for attributes, and when rendering so that characters like quotation marks and ampersands are encoded appropriately).

(I deliberately did not modify the output of the_subtitle, only cases where HTML was being outputted directly)
